### PR TITLE
Add folder picker to GUI for batch translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+translated_cache.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ python -m sims4_auto_translator.main gui
 
 _Output directory will contain subfolders named `source-target`._
 
+In the GUI you can now select the Sims 4 game folder. Every `.strings` file
+found inside that folder will be translated and written either back to the game
+folder or to a directory you choose.
+
+You can also tick **Create .package** to generate a mod package alongside the
+translated `.strings` files.
+
 ![CLI](cli.png)
 ![GUI](gui.png)
 

--- a/sims4_auto_translator/gui.py
+++ b/sims4_auto_translator/gui.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+import os
 import tkinter as tk
 import tkinter.ttk as ttk
 from pathlib import Path
 from tkinter import filedialog, messagebox
 
 from .deepl_api import DeepLTranslator
-from .parsers import parse_strings_file, write_strings_file, mask_placeholders, unmask_placeholders
-from .utils import console
+from .parsers import (
+    mask_placeholders,
+    parse_strings_file,
+    unmask_placeholders,
+    write_strings_file,
+)
+from .packer import pack_strings_to_package
+
 
 
 def run_gui() -> None:
@@ -24,40 +31,68 @@ def run_gui() -> None:
 
     apikey_var = tk.StringVar()
     tk.Label(root, text='DeepL API Key:').grid(row=2, column=0, sticky='e')
-    tk.Entry(root, textvariable=apikey_var, width=40).grid(row=2, column=1)
+    tk.Entry(root, textvariable=apikey_var, width=40).grid(row=2, column=1, columnspan=2, sticky='ew')
+
+    tk.Label(root, text='Game Folder:').grid(row=3, column=0, sticky='e')
+    game_var = tk.StringVar()
+    tk.Entry(root, textvariable=game_var, width=40).grid(row=3, column=1, sticky='ew')
+    tk.Button(root, text='Browse', command=lambda: game_var.set(filedialog.askdirectory())).grid(row=3, column=2)
+
+    tk.Label(root, text='Output Folder:').grid(row=4, column=0, sticky='e')
+    output_var = tk.StringVar()
+    tk.Entry(root, textvariable=output_var, width=40).grid(row=4, column=1, sticky='ew')
+    tk.Button(root, text='Browse', command=lambda: output_var.set(filedialog.askdirectory())).grid(row=4, column=2)
+    use_game_var = tk.BooleanVar(value=False)
+    tk.Checkbutton(root, text='Use Game Folder', variable=use_game_var).grid(row=4, column=3, sticky='w')
+
+    pack_var = tk.BooleanVar(value=False)
+    tk.Checkbutton(root, text='Create .package', variable=pack_var).grid(row=5, column=0, columnspan=2, sticky='w')
 
     progress = tk.IntVar(value=0)
     progress_bar = tk.ttk.Progressbar(root, variable=progress, maximum=100)
-    progress_bar.grid(row=4, column=0, columnspan=2, sticky='ew', pady=5)
+    progress_bar.grid(row=6, column=0, columnspan=4, sticky='ew', pady=5)
 
     def start_translation() -> None:
-        file_path = filedialog.askopenfilename(title='Select strings file')
-        if not file_path:
+        folder = game_var.get()
+        if not folder:
+            messagebox.showerror('Error', 'Game folder not selected')
             return
+        output_root = Path(output_var.get()) if output_var.get() else None
+        if use_game_var.get() or output_root is None:
+            output_root = Path(folder)
         source = source_var.get().upper()
         target = target_var.get().upper()
+        file_list = list(Path(folder).rglob('*.strings'))
+        if not file_list:
+            messagebox.showerror('Error', 'No .strings files found')
+            return
         key = apikey_var.get() or os.environ.get('DEEPL_AUTH_KEY', '')
         if not key:
             messagebox.showerror('Error', 'API key required')
             return
         translator = DeepLTranslator(key)
-        entries = parse_strings_file(Path(file_path))
-        texts = [e[1] for e in entries]
-        masked = []
-        maps = []
-        for t in texts:
-            m, mp = mask_placeholders(t)
-            masked.append(m)
-            maps.append(mp)
-        translated = translator.translate(masked, source, target)
-        restored = [unmask_placeholders(t, mp) for t, mp in zip(translated, maps)]
-        out_dir = Path('output') / f"{source.lower()}-{target.lower()}"
-        out_dir.mkdir(parents=True, exist_ok=True)
-        write_strings_file(zip([e[0] for e in entries], restored), out_dir / Path(file_path).name)
-        progress.set(100)
-        messagebox.showinfo('Done', f'Translation saved to {out_dir}')
+        progress_bar.configure(maximum=len(file_list))
+        progress.set(0)
+        for idx, fp in enumerate(file_list, start=1):
+            entries = parse_strings_file(fp)
+            texts = [e[1] for e in entries]
+            masked = []
+            maps = []
+            for t in texts:
+                m, mp = mask_placeholders(t)
+                masked.append(m)
+                maps.append(mp)
+            translated = translator.translate(masked, source, target)
+            restored = [unmask_placeholders(t, mp) for t, mp in zip(translated, maps)]
+            out_path = output_root / fp.relative_to(folder)
+            write_strings_file(zip([e[0] for e in entries], restored), out_path)
+            if pack_var.get():
+                pack_strings_to_package(zip([e[0] for e in entries], restored), out_path.with_suffix('.package'))
+            progress.set(idx)
+            root.update_idletasks()
+        messagebox.showinfo('Done', f'Translated files saved to {output_root}')
 
-    tk.Button(root, text='Translate', command=start_translation).grid(row=3, column=0, columnspan=2, pady=5)
+    tk.Button(root, text='Translate', command=start_translation).grid(row=7, column=0, columnspan=4, pady=5)
 
     root.mainloop()
 

--- a/sims4_auto_translator/packer.py
+++ b/sims4_auto_translator/packer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import subprocess
+import tempfile
+import zipfile
 from pathlib import Path
 from typing import Iterable, Tuple
 
@@ -9,12 +10,10 @@ from .utils import console
 
 
 def pack_strings_to_package(strings: Iterable[Tuple[str, str]], output_path: Path) -> None:
-    temp_dir = output_path.parent / 'temp_strings'
-    write_strings_file(strings, temp_dir / 'language.strings')
-    # Placeholder for real packaging logic
-    try:
-        subprocess.run(['S4Studio', '-batchfix', str(temp_dir)], check=True)
-    except FileNotFoundError:
-        console.print('[yellow]S4Studio not found, skipping package packing[/yellow]')
+    """Write strings to a simple .package (ZIP based) archive."""
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    (temp_dir / 'language.strings').replace(output_path.with_suffix('.strings'))
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp) / "language.strings"
+        write_strings_file(strings, tmp_path)
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.write(tmp_path, arcname="language.strings")

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -1,0 +1,14 @@
+import sys, pathlib, zipfile
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from sims4_auto_translator.packer import pack_strings_to_package
+
+
+def test_pack(tmp_path):
+    out = tmp_path / "test.package"
+    data = [("key", "Value")]
+    pack_strings_to_package(data, out)
+    assert out.exists()
+    with zipfile.ZipFile(out) as zf:
+        assert "language.strings" in zf.namelist()
+        content = zf.read("language.strings").decode("utf-8").strip()
+    assert content == "key = Value"


### PR DESCRIPTION
## Summary
- allow selecting a Sims 4 game folder in the GUI
- translate every `.strings` file found under that folder
- option to write translations back into the game folder or another folder
- add ability to generate a `.package` file for each translated `strings`
- document the new GUI feature

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f26421e7c8329a95a2a79ad237400