### PR TITLE
Handle compressed STBL files

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from sims4_auto_translator import deepl_api
 from sims4_auto_translator.deepl_api import DeepLTranslator
 
 
@@ -15,6 +16,7 @@ def test_cache(tmp_path, monkeypatch):
         return Resp()
 
     monkeypatch.setattr('sims4_auto_translator.deepl_api.requests.post', fake_post)
+    monkeypatch.setattr(deepl_api, 'CACHE_PATH', tmp_path / 'cache.json')
     translator = DeepLTranslator('testkey')
     result1 = translator.translate(['hello'], 'EN', 'UK')
     result2 = translator.translate(['hello'], 'EN', 'UK')

--- a/tests/test_compressed_stbl.py
+++ b/tests/test_compressed_stbl.py
@@ -1,0 +1,27 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from sims4_auto_translator.dbpf import build_stbl, parse_stbl
+import struct, zlib
+
+
+def test_parse_zlib_wrapped_stbl():
+    data = build_stbl([("0x1", "Hello")])
+    wrapped = zlib.compress(data)
+    result = parse_stbl(wrapped)
+    assert result == [("0x00000001", "Hello")]
+
+
+def test_parse_internal_compressed_stbl():
+    data = build_stbl([("0x2", "World")])
+    # compress the strings section and set the flag
+    header = bytearray(data)
+    string_len = struct.unpack("<I", header[17:21])[0]
+    strings = bytes(header[21:21 + string_len])
+    compressed = zlib.compress(strings)
+    header[6] = 1
+    header[17:21] = struct.pack("<I", len(compressed))
+    header[21:21 + string_len] = compressed
+    compressed_stbl = bytes(header[:21 + len(compressed)])
+    result = parse_stbl(compressed_stbl)
+    assert result == [("0x00000002", "World")]


### PR DESCRIPTION
## Summary
- support STBL's internal compression flag
- keep tests independent of repo cache
- test both zlib-wrapped and internally compressed STBLs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f34099ce88329ad33eaab6476ae5e